### PR TITLE
Add concurrency and caching to badges

### DIFF
--- a/badges.go
+++ b/badges.go
@@ -9,9 +9,8 @@ import (
 	"os"
 )
 
-func worker(pids <-chan int, pp *PlayerDataFetcher, skins map[string]Skin) {
-	// cairo surface cache
-	surfaceCache := make(map[string]*cairo.Surface)
+func renderWorker(pids <-chan int, pp *PlayerDataFetcher, skins map[string]Skin,
+	surfaceCache map[string]*cairo.Surface) {
 
 	for pid := range pids {
 		pd, err := pp.GetPlayerData(pid)
@@ -67,11 +66,13 @@ func main() {
 		}
 	}
 
+	surfaceCache := LoadSurfaces(skins)
+
 	pidsChan := make(chan int, *workers)
 
 	// start workers
 	for w := 1; w <= *workers; w++ {
-		go worker(pidsChan, pp, skins)
+		go renderWorker(pidsChan, pp, skins, surfaceCache)
 	}
 
 	// send them work

--- a/badges.go
+++ b/badges.go
@@ -4,8 +4,10 @@ import (
 	"flag"
 	"fmt"
 	"github.com/antzucaro/badges/config"
+	"github.com/ungerik/go-cairo"
 	"log"
 	"os"
+	"runtime/pprof"
 )
 
 func main() {
@@ -46,19 +48,31 @@ func main() {
 		}
 	}
 
+	// CPU profiling
+	f, err := os.Create("cpuprofile.dat")
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	pprof.StartCPUProfile(f)
+	defer pprof.StopCPUProfile()
+
+	// cairo surface cache
+	surfaceCache := make(map[string]*cairo.Surface)
+
 	for _, pid := range pids {
 		pd, err := pp.GetPlayerData(pid)
 		if err != nil {
 			fmt.Println(err)
 		}
 
-        if len(pd.Nick) == 0 {
-            fmt.Printf("No data for player #%d!\n", pid)
-        } else {
-            fmt.Printf("Rendering images for player #%d\n", pid)
-            for name, skin := range skins {
-                skin.Render(pd, fmt.Sprintf("output/%s/%d.png", name, pid))
-            }
-        }
+		if len(pd.Nick) == 0 {
+			fmt.Printf("No data for player #%d!\n", pid)
+		} else {
+			fmt.Printf("Rendering images for player #%d\n", pid)
+			for name, skin := range skins {
+				skin.Render(pd, fmt.Sprintf("output/%s/%d.png", name, pid), surfaceCache)
+			}
+		}
 	}
 }

--- a/player.go
+++ b/player.go
@@ -60,9 +60,9 @@ func (pd *PlayerData) WinPct() float64 {
 // DurationString creates a human-readable duration string with a days component.
 func DurationString(d time.Duration) string {
 	minutes := uint64(d.Minutes())
-	days := uint64(minutes /1440)
+	days := uint64(minutes / 1440)
 	minutes -= days * 1440
-	hours := uint64(minutes /60)
+	hours := uint64(minutes / 60)
 	minutes -= hours * 60
 
 	var buffer bytes.Buffer
@@ -72,7 +72,7 @@ func DurationString(d time.Duration) string {
 		buffer.WriteString(fmt.Sprintf("%d days", days))
 	}
 
-	if hours >= 1 && days >=1 {
+	if hours >= 1 && days >= 1 {
 		buffer.WriteString(", ")
 	}
 
@@ -82,7 +82,7 @@ func DurationString(d time.Duration) string {
 		buffer.WriteString(fmt.Sprintf("%d hrs", hours))
 	}
 
-	if minutes >= 1 && hours >=1 {
+	if minutes >= 1 && hours >= 1 {
 		buffer.WriteString(", ")
 	}
 
@@ -169,7 +169,7 @@ func (pp *PlayerDataFetcher) FindPlayers(delta int, limit int) ([]int, error) {
 // genPlayerDataStmt generates the SQL statement string used to fetch
 // the information used to populate PlayerData objects
 func (pp *PlayerDataFetcher) genPlayerDataStmt(playerID int) string {
-    query := `
+	query := `
 SELECT
     p.nick,
     p.stripped_nick,


### PR DESCRIPTION
Several speedups for badge generation:

* Use a cache for cairo surfaces to prevent loading the same (twelve) images from the filesystem again and again.
* Create a simple rendering worker pool for concurrency.

Overall this results in a 3x improvement on my local machine. 